### PR TITLE
fix: split ci jobs and correct workdir

### DIFF
--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -23,6 +23,8 @@ on:
       - '.github/**'
       - '.gitignore'
       
+permissions:
+  contents: read
 jobs:
   golangci-lint:
     name: golangci-lint (Backend)

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -1,0 +1,39 @@
+name: Lint Backend
+
+on:
+  push:
+    branches:
+      - 'fix*' 
+      - 'feat*' 
+    paths:
+      - 'backend/**'
+      - '.golangci.yml'
+      - 'docker-compose.yml'
+      - 'Makefile'
+      - '.github/**'
+      - '.gitignore'
+
+  pull_request:
+    types: [opened, synchronize, reopened] 
+    paths:
+      - 'backend/**'
+      - '.golangci.yml'
+      - 'docker-compose.yml'
+      - 'Makefile'
+      - '.github/**'
+      - '.gitignore'
+      
+jobs:
+  golangci-lint:
+    name: golangci-lint (Backend)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8 
+        with:
+          working-directory: backend/
+          version: latest
+          args: --config=../.golangci.yml --timeout 5m

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint Frontend
 
 on:
   push:
@@ -6,41 +6,25 @@ on:
       - 'fix*' 
       - 'feat*' 
     paths:
-      - 'backend/**'
       - 'frontend/**'
-      - '.golangci.yml'
-      - 'package.json'
-      - 'package-lock.json' 
-      - 'frontend/biome.json' 
+      - 'docker-compose.yml'
+      - '.gitignore'
+      - 'Makefile'
 
   pull_request:
     types: [opened, synchronize, reopened] 
     paths:
-      - 'backend/**'
       - 'frontend/**'
-      - '.golangci.yml'
-      - 'package.json'
-      - 'package-lock.json' 
-      - 'frontend/biome.json'
+      - 'docker-compose.yml'
+      - '.gitignore'
+      - 'Makefile'
       
 jobs:
-  golangci-lint:
-    name: golangci-lint (Backend)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8 
-        with:
-          working-directory: backend/
-          version: latest
-          args: --config=../.golangci.yml --timeout 5m
-
   biome-lint:
     name: Biome Lint (Frontend)
     runs-on: ubuntu-latest
+    defaults:
+      working-directory: frontend/
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,7 +36,6 @@ jobs:
           cache: 'npm' 
 
       - name: Install Frontend Dependencies
-        working-directory: frontend/ 
         run: npm ci 
 
       - name: Setup Biome CLI
@@ -61,5 +44,5 @@ jobs:
           version: latest 
 
       - name: Run Biome CI
-        working-directory: frontend/ 
         run: biome ci . 
+

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.1.4/schema.json",
 	"vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
 	"files": { "ignoreUnknown": false },
 	"formatter": { "enabled": true, "indentStyle": "tab" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
 		"zustand": "^5.0.6"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.1.3",
+		"@biomejs/biome": "2.1.4",
 		"@types/react": "^19.1.8",
 		"@types/react-dom": "^19.1.6",
 		"@types/react-router-dom": "^5.3.3",


### PR DESCRIPTION

## Pull Request: [CI]: Fix frontend ci workflow and split jobs

---

### **1. Overview**

Jobs should run based on type of change and workdir was wrong for the frontend npm setup

### **2. Changes Made**


*   change workdir in frontend lint
*   split jobs and set trigger on according paths

### **3. Motivation / Reasoning**

Jobs should run based on type of change and workdir was wrong for the frontend npm setup

### **4. How to Test**

1.  watch this PR

### **5. Breaking Changes / Migrations**

*  No

### **10. Further Work / Notes (Optional)**

I don't like these, I believe they need some love 
---
