### PR TITLE
Potential fix for code scanning alert no. 1: Slice memory allocation with excessive size value

### DIFF
--- a/backend/internal/handlers/user_handler.go
+++ b/backend/internal/handlers/user_handler.go
@@ -64,6 +64,7 @@ func (h *UserHandler) GetUserByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *UserHandler) GetAllUsers(w http.ResponseWriter, r *http.Request) {
+	const MaxLimit = 100
 	ctx := r.Context()
 
 	limitStr := r.URL.Query().Get("limit")
@@ -72,6 +73,8 @@ func (h *UserHandler) GetAllUsers(w http.ResponseWriter, r *http.Request) {
 	limit, err := strconv.Atoi(limitStr)
 	if err != nil || limit <= 0 {
 		limit = 10
+	} else if limit > MaxLimit {
+		limit = MaxLimit
 	}
 
 	offset, err := strconv.Atoi(offsetStr)


### PR DESCRIPTION
Potential fix for [https://github.com/escuadron-404/red404/security/code-scanning/1](https://github.com/escuadron-404/red404/security/code-scanning/1)

To fix the problem, we need to enforce a maximum allowed value for the `limit` parameter before it is used for slice allocation. The best place to do this is in the handler (`GetAllUsers` in `user_handler.go`), where user input is first parsed. This ensures that all downstream code receives a safe, bounded value. We should define a reasonable constant, e.g., `const MaxLimit = 100`, and clamp `limit` to this value if the user provides a larger number. This change should be made in the handler, and no changes are needed in the service or repository layers, as they will now only receive safe values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
