### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint Frontend
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/escuadron-404/red404/security/code-scanning/5](https://github.com/escuadron-404/red404/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege required. Since the workflow only checks out code and runs linting tools, it only needs read access to repository contents. The best way to do this is to add the following block at the top level of the workflow (before `jobs:`), so it applies to all jobs unless overridden:

```yaml
permissions:
  contents: read
```

This should be added after the `name:` and before the `on:` block in `.github/workflows/lint-frontend.yml`. No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
